### PR TITLE
Simplify installation of openfast in docker container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Get package version
         run: echo "PACKAGE_VERSION=$(poetry version -s)" >> $GITHUB_ENV
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -56,4 +59,5 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64
           tags: octue/openfast:${{ env.PACKAGE_VERSION }},octue/openfast:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR $PROJECT_ROOT
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 # Install openfast.
-RUN yes | conda create -n openfast_env && yes | conda install -c conda-forge openfast=3.1.0
+RUN conda config --add channels conda-forge && conda install -y openfast=3.1.0
 
 # Install the useful extra OpenFAST/python-toolbox in the recommended way.
 RUN git clone https://github.com/OpenFAST/python-toolbox && cd python-toolbox && python3 -m pip install -e .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# OpenFast Docker
+# OpenFAST Docker
 This repository contains a Dockerfile for producing working installations of 
 [OpenFAST](https://github.com/OpenFAST/openfast) in a python/conda-based docker image. Releases trigger a build of and
-push to the [`octue/openfast`](https://hub.docker.com/r/octue/openfast) DockerHub repository. Each tag matches the 
+push to the [`octue/openfast`](https://hub.docker.com/r/octue/openfast) DockerHub repository. Each image tag matches the 
 version number of the release, which in turn matches the version of OpenFAST installed in that image. The containers are
 built for the `linux/amd64` platform.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# OpenFast Docker
+This repository contains a Dockerfile for producing working installations of 
+[OpenFAST](https://github.com/OpenFAST/openfast) in a python/conda-based docker image. Releases trigger a build of and
+push to the [`octue/openfast`](https://hub.docker.com/r/octue/openfast) DockerHub repository. Each tag matches the 
+version number of the release, which in turn matches the version of OpenFAST installed in that image. The containers are
+built for the `linux/amd64` platform.
+
+## Installation
+Running the following will get you an image with `openfast==3.1.0` installed:
+```shell
+docker pull octue/openfast:3.1.0
+```
+
+## Usage
+To run openfast on files on your local machine, mount them while creating a new container from the image you pulled:
+```shell
+docker run -v /path/to/openfast-files:/data -it octue/openfast:3.1.0
+
+openfast /data/main.fst
+```


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#4](https://github.com/octue/openfast-docker/pull/4))

### Operations
- Ensure docker image is built for `linux/amd64`

### Refactoring
- Simplify installation of `openfast` in docker container

### Other
- Add `README`

<!--- END AUTOGENERATED NOTES --->